### PR TITLE
Fix version typed-ts-events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5781,9 +5781,9 @@
       }
     },
     "typed-ts-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/typed-ts-events/-/typed-ts-events-1.0.5.tgz",
-      "integrity": "sha512-0a76E5Nc0t1L5YeOqYTLztuMrIT5FCGxzKVzowad0BR0ubS4BC+N2oisp3GI6ARnzwvvTyviYrwD+u6wmdNLTQ=="
+      "version": "1.1.1",
+      "resolved": "https://artifactory.infrateam.xyz:443/api/npm/npm/typed-ts-events/-/typed-ts-events-1.1.1.tgz",
+      "integrity": "sha1-d3hTSJmPVcZuxMHUBmd4brdWqIk="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "@types/node": "^11.9.4",
-    "typed-ts-events": "^1.0.5"
+    "typed-ts-events": "1.1.1"
   }
 }


### PR DESCRIPTION
Под версию ^1.0.5 попадает версия typed-ts-events@1.2.1 которая содержит в себе arrow function которые падают в IE11

Запаблишете пожалалуйста после мержа 